### PR TITLE
Backport 5.8: AP-25788: Dump log buffer in shutdown hook if not yet initialized

### DIFF
--- a/org.knime.core.tests/src/org/knime/core/node/logging/KNIMELoggerTest.java
+++ b/org.knime.core.tests/src/org/knime/core/node/logging/KNIMELoggerTest.java
@@ -49,8 +49,17 @@
 package org.knime.core.node.logging;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.io.output.NullWriter;
+import org.apache.log4j.Layout;
 import org.apache.log4j.Level;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -159,5 +168,163 @@ class KNIMELoggerTest {
         logger.error(thirdMsg);
         m_logStack.assertLastLogMessageEquals(Level.ERROR, thirdMsg);
         m_logStack.assertFirstLogMessageEquals(Level.ERROR, firstMsg);
+    }
+
+    @Test
+    void testLogRejectsNullLevelForObjectMessage() {
+        final var logger = KNIMELogger.getLogger(LOGGER_NAME);
+        assertThrows(NullPointerException.class, () -> logger.log(null, "message", true, null));
+    }
+
+    @Test
+    void testLogRejectsNullLevelForSupplierMessage() {
+        final var logger = KNIMELogger.getLogger(LOGGER_NAME);
+        assertThrows(NullPointerException.class, () -> logger.log(null, () -> "message", true, null));
+    }
+
+    @Test
+    void testFailsafeDrainSkipsEmptyBuffer() {
+        final var out = new ByteArrayOutputStream();
+        final var router = new StartupLogRouter(2, new PrintStream(out), Level.DEBUG, createFailsafeLayout());
+        router.activateFailsafeAndDrain();
+        assertEquals("", out.toString(StandardCharsets.UTF_8), "Expected no failsafe output for empty buffer");
+    }
+
+    @Test
+    void testFailsafeDrainSkipsMessagesBelowMinLevel() {
+        final var out = new ByteArrayOutputStream();
+        final var router = new StartupLogRouter(2, new PrintStream(out), Level.INFO, createFailsafeLayout());
+        router.route(() -> false, Level.DEBUG, LOGGER_NAME, "debug message", null);
+
+        router.activateFailsafeAndDrain();
+        assertEquals("", out.toString(StandardCharsets.UTF_8),
+            "Expected no failsafe output if all messages are below the minimum level");
+    }
+
+    @Test
+    void testFailsafeDrainEmitsEvictionNoticeAndMatchingMessages() {
+        final var out = new ByteArrayOutputStream();
+        final var router = new StartupLogRouter(2, new PrintStream(out), Level.INFO, createFailsafeLayout());
+        router.route(() -> false, Level.ERROR, LOGGER_NAME, "first", null);
+        router.route(() -> false, Level.INFO, LOGGER_NAME, "second", null);
+        router.route(() -> false, Level.WARN, LOGGER_NAME, "third", null);
+
+        router.activateFailsafeAndDrain();
+        final var dump = out.toString(StandardCharsets.UTF_8);
+
+        assertTrue(dump.contains("3 messages were buffered."),
+            "Expected failsafe dump header");
+        assertTrue(dump.contains("evicted from buffer in total"), "Expected eviction notice");
+        assertTrue(dump.contains("second"), "Expected INFO message in dump");
+        assertTrue(dump.contains("third"), "Expected WARN message in dump");
+        assertFalse(dump.contains("first"), "Expected evicted message to be absent");
+        assertTrue(dump.contains("End of KNIME startup failsafe logging dump."),
+            "Expected failsafe dump footer");
+    }
+
+    @Test
+    void testFailsafeEmitSupplierDoesNotEvaluateBelowMinLevel() {
+        final var evaluated = new AtomicBoolean();
+        final var out = new ByteArrayOutputStream();
+        final var router = new StartupLogRouter(2, new PrintStream(out), Level.INFO, createFailsafeLayout());
+        router.activateFailsafeAndDrain();
+
+        router.route(() -> false, Level.DEBUG, LOGGER_NAME, () -> {
+                evaluated.set(true);
+                return "message";
+            }, null);
+
+        assertFalse(evaluated.get(), "Supplier should not be evaluated below the minimum failsafe level");
+        assertEquals("", out.toString(StandardCharsets.UTF_8), "Expected no failsafe output below minimum level");
+    }
+
+    @Test
+    void testFailsafeEmitPrintsThrowableIfLayoutIgnoresIt() {
+        final var out = new ByteArrayOutputStream();
+        final var ex = new IllegalStateException("boom");
+        final var router = new StartupLogRouter(2, new PrintStream(out), Level.DEBUG, createThrowableIgnoringLayout());
+        router.activateFailsafeAndDrain();
+
+        router.route(() -> false, Level.ERROR, LOGGER_NAME, "message", ex);
+
+        final var emitted = out.toString(StandardCharsets.UTF_8);
+        assertTrue(emitted.contains("message"), "Expected formatted message output");
+        assertTrue(emitted.contains("IllegalStateException: boom"), "Expected throwable stack trace output");
+    }
+
+    @Test
+    void testDrainToLoggerWithEmptyBufferDoesNotInvokeConsumer() {
+        final var router = new StartupLogRouter(2);
+        final var called = new AtomicBoolean();
+        router.drainToLogger(m -> called.set(true));
+        assertFalse(called.get(), "Consumer should not be called when draining an empty buffer");
+    }
+
+    @Test
+    void testRouteReturnsFalseAfterLoggerDrain() {
+        final var router = new StartupLogRouter(2);
+        router.route(() -> false, Level.DEBUG, LOGGER_NAME, "before drain", null);
+        router.drainToLogger(m -> { /* discard */ });
+        assertFalse(router.route(() -> false, Level.DEBUG, LOGGER_NAME, "after drain", null),
+            "Expected route() to return false (unhandled) after buffer has been drained to logger");
+    }
+
+    @Test
+    void testFailsafeEmitSupplierAboveMinLevelEmitsMessage() {
+        final var evaluated = new AtomicBoolean();
+        final var out = new ByteArrayOutputStream();
+        final var router = new StartupLogRouter(2, new PrintStream(out), Level.DEBUG, createFailsafeLayout());
+        router.activateFailsafeAndDrain();
+
+        router.route(() -> false, Level.INFO, LOGGER_NAME, () -> {
+                evaluated.set(true);
+                return "supplier message";
+            }, null);
+
+        assertTrue(evaluated.get(), "Supplier should be evaluated at or above the minimum failsafe level");
+        assertTrue(out.toString(StandardCharsets.UTF_8).contains("supplier message"),
+            "Expected supplier message in failsafe output");
+    }
+
+    @Test
+    void testFailsafeDrainEmitsHeaderLazilyOnFirstQualifyingMessage() {
+        final var out = new ByteArrayOutputStream();
+        // buffer size > number of messages, so no eviction
+        final var router = new StartupLogRouter(4, new PrintStream(out), Level.INFO, createFailsafeLayout());
+        router.route(() -> false, Level.INFO, LOGGER_NAME, "first", null);
+        router.route(() -> false, Level.INFO, LOGGER_NAME, "second", null);
+
+        router.activateFailsafeAndDrain();
+        final var dump = out.toString(StandardCharsets.UTF_8);
+
+        assertTrue(dump.contains("2 messages were buffered."), "Expected header in dump");
+        assertFalse(dump.contains("evicted"), "Expected no eviction notice without overflow");
+        assertTrue(dump.contains("first"), "Expected first message in dump");
+        assertTrue(dump.contains("second"), "Expected second message in dump");
+    }
+
+    private static Layout createFailsafeLayout() {
+        final var layout = new org.knime.core.node.NodeLoggerPatternLayout();
+        layout.setConversionPattern("%d{ISO8601} : %-5p : %t : %c{1} : %m%n");
+        layout.activateOptions();
+        return layout;
+    }
+
+    private static Layout createThrowableIgnoringLayout() {
+        return new Layout() {
+            @Override
+            public void activateOptions() {
+            }
+
+            @Override
+            public String format(final org.apache.log4j.spi.LoggingEvent event) {
+                return event.getMessage() + System.lineSeparator();
+            }
+
+            @Override
+            public boolean ignoresThrowable() {
+                return true;
+            }
+        };
     }
 }

--- a/org.knime.core.tests/src/org/knime/core/node/logging/LogInterceptor.java
+++ b/org.knime.core.tests/src/org/knime/core/node/logging/LogInterceptor.java
@@ -125,6 +125,12 @@ class LogInterceptor extends Layout {
         expectLogMessageEquals(true, level, expected);
     }
 
+    void assertContainsLogMessage(final Level level, final String expected) {
+        assertThat(m_stack) //
+            .as(() -> "Expected log stack to contain message \"%s\" at level %s".formatted(expected, level)) //
+            .contains(new LogMsg(level, expected));
+    }
+
     boolean isEmpty() {
         return m_stack.isEmpty();
     }

--- a/org.knime.core.tests/src/org/knime/core/node/logging/NodeLoggerInitializationTest.java
+++ b/org.knime.core.tests/src/org/knime/core/node/logging/NodeLoggerInitializationTest.java
@@ -50,9 +50,13 @@ package org.knime.core.node.logging;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.NoSuchElementException;
 
 import org.apache.commons.io.output.NullWriter;
 import org.apache.log4j.Level;
@@ -66,6 +70,7 @@ import org.junit.jupiter.api.Test;
 import org.knime.core.node.NodeLogger;
 import org.knime.core.node.NodeLogger.LEVEL;
 import org.knime.core.node.logging.LogBuffer.BufferedLogMessage;
+import org.knime.core.node.logging.LogBuffer.DrainResult;
 
 /**
  * Tests that the node logger can be used prior to setting the workspace (instance location) and still
@@ -98,13 +103,56 @@ class NodeLoggerInitializationTest {
         final var buffer = new LogBuffer(3);
         final var msgs = new String[] { "First", "Second", "Third" };
         for (final var msg : msgs) {
-            buffer.log(Level.DEBUG, "testing", msg, null);
+            buffer.add(Level.DEBUG, "testing", msg, null);
         }
+        final DrainResult result = buffer.drain();
+        assertNotNull(result, "Expected non-null drain result for non-empty buffer");
         final var buffered = new ArrayList<BufferedLogMessage>();
-        buffer.drainTo(buffered::add);
-        final var bufferedMessages = buffered.stream().map(BufferedLogMessage::message)
-                .toArray(String[]::new);
+        result.messages().forEachRemaining(buffered::add);
+        final var bufferedMessages = buffered.stream().map(BufferedLogMessage::message).toArray(String[]::new);
         assertArrayEquals(msgs, bufferedMessages, "Unexpected messages received while draining buffer");
+    }
+
+    @Test
+    void testEmptyBufferDrainReturnsNull() {
+        final var buffer = new LogBuffer(3);
+        assertTrue(buffer.isEmpty(), "Freshly created buffer should be empty");
+        assertNull(buffer.drain(), "Expected null drain result for empty buffer");
+    }
+
+    @Test
+    void testBufferIteratorThrowsOnExhaustion() {
+        final var buffer = new LogBuffer(1);
+        buffer.add(Level.DEBUG, "test", "msg", null);
+        final var result = buffer.drain();
+        result.messages().next(); // consume the single entry
+        assertThrows(NoSuchElementException.class, () -> result.messages().next(),
+            "Expected NoSuchElementException when advancing exhausted iterator");
+    }
+
+    @Test
+    void testDrainToLogsOverflowNotice() {
+        KNIMELogger.initializeLogging(false);
+        final var logStack = new LogInterceptor(KNIMELogger.class.getName());
+        KNIMELogger.addWriter(WRITER, logStack, LEVEL.DEBUG, LEVEL.FATAL);
+
+        final var router = new StartupLogRouter(2);
+        router.route(() -> false, Level.FATAL, "testing", "First", null);
+        router.route(() -> false, Level.DEBUG, "testing", "Second", null);
+        router.route(() -> false, Level.INFO, "testing", "Third", null);
+
+        final var drainedMessages = new ArrayList<BufferedLogMessage>();
+        router.drainToLogger(drainedMessages::add);
+
+        final var bufferedMessages = drainedMessages.stream().map(BufferedLogMessage::message)
+            .toArray(String[]::new);
+        assertArrayEquals(new String[]{"Second", "Third"}, bufferedMessages,
+            "Unexpected messages received while draining evicting buffer");
+        logStack.assertFirstLogMessageEquals(Level.DEBUG, "3 messages were logged before logging was initialized; "
+            + "see below...");
+        logStack.assertContainsLogMessage(Level.FATAL,
+            "[*** Log incomplete: log buffer did wrap around -- 1 messages were evicted from buffer in total ***]");
+        logStack.assertLastLogMessageEquals(Level.DEBUG, "End of buffered log messages");
     }
 
     @Test

--- a/org.knime.core/src/eclipse/org/knime/core/node/logging/KNIMELogger.java
+++ b/org.knime.core/src/eclipse/org/knime/core/node/logging/KNIMELogger.java
@@ -152,6 +152,19 @@ import org.knime.core.util.Pair;
  * <b>Note:</b> it is assumed that in the "uninitialized" state, no workflow log messages are supposed to be
  * logged.
  *
+ * <h3>Failsafe logging</h3>
+ *
+ * If the JVM shuts down before initialization completes, buffered messages are emitted to a configurable output
+ * stream (the <em>failsafe</em> path) so that startup log messages are not silently lost. Two environment variables
+ * control this behaviour:
+ * <ul>
+ *   <li>{@code KNIME_CORE_LOGGING_FAILSAFE_TARGET} — output target: {@code stderr} (case-insensitive) writes to
+ *       {@code stderr}; any other value (or unset) writes to {@code stdout}.</li>
+ *   <li>{@code KNIME_CORE_LOGGING_FAILSAFE_MIN_LEVEL} — minimum log level emitted to the failsafe output; any
+ *       valid Log4j&nbsp;1 level name (case-insensitive), e.g. {@code INFO}. Defaults to {@code DEBUG} if unset
+ *       or unrecognised.</li>
+ * </ul>
+ *
  * <p>
  * Such a two-phase logging lifecycle is useful in the following (currently in place) scenario:
  * <br>
@@ -180,8 +193,8 @@ public final class KNIMELogger {
         }
     }
 
-    // shared buffer for all instances used before logging is initialized
-    private static final LogBuffer BUFFER = new LogBuffer(1024);
+    // assuming 1KB per message on average, this would be around 32MB of memory
+    private static final StartupLogRouter STARTUP_ROUTER = new StartupLogRouter(1 << 15);
 
     private static volatile boolean isInitialized;
 
@@ -964,9 +977,7 @@ public final class KNIMELogger {
      */
     static void logBufferedMessages() {
         checkInitializedState();
-        synchronized(BUFFER) {
-            BUFFER.drainTo(bufferedMessage -> getLogger(bufferedMessage.name()).log(bufferedMessage));
-        }
+        STARTUP_ROUTER.drainToLogger(bufferedMessage -> getLogger(bufferedMessage.name()).log(bufferedMessage));
     }
 
     private void log(final BufferedLogMessage bufferedMessage) {
@@ -974,28 +985,21 @@ public final class KNIMELogger {
     }
 
     /**
-     * Log the message from the supplier at the specified level.
-     * The message supplier may or may not get invoked immediately (or at all).
+     * Log the message from the supplier at the specified level. The message supplier may or may not get invoked
+     * immediately (or at all).
      *
      * @param level level to log under
-     * @param messageSupplier supplier for the message
+     * @param msg supplier for the message
      * @param omitContext if {@code true}, any available context information (e.g. node id) will not be logged
      * @param cause optional cause for the log message
      */
-    public void log(final Level level, final Supplier<Object> messageSupplier, final boolean omitContext,
-            final Throwable cause) {
-        // we double-check to avoid expensive locking
-        if (!isInitialized()) {
-            synchronized(BUFFER) {
-                // we need to check again now that we have the lock to see if someone else has initialized it in the
-                // meantime
-                if (!isInitialized()) {
-                    BUFFER.log(level, m_name, messageSupplier.get(), cause);
-                    return;
-                }
-            }
+    public void log(final Level level, final Supplier<Object> msg, final boolean omitContext, final Throwable cause) {
+        Objects.requireNonNull(level, "Must not log a null level");
+        // we double-check (here and in #route) to avoid expensive locking on the happy path
+        if (!isInitialized() && STARTUP_ROUTER.route(KNIMELogger::isInitialized, level, m_name, msg, cause)) {
+            return;
         }
-        m_logger.log(level, messageSupplier, omitContext, cause);
+        m_logger.log(level, msg, omitContext, cause);
     }
 
     /**
@@ -1006,16 +1010,11 @@ public final class KNIMELogger {
      * @param omitContext if {@code true}, any available context information (e.g. node id) will not be logged
      * @param cause optional cause for the log message
      */
-    public void log(final Level level, final Object message, final boolean omitContext,
-            final Throwable cause) {
-        // we double-check to avoid expensive locking
-        if (!isInitialized()) {
-            synchronized(BUFFER) {
-                if (!isInitialized()) {
-                    BUFFER.log(level, m_name, message, cause);
-                    return;
-                }
-            }
+    public void log(final Level level, final Object message, final boolean omitContext, final Throwable cause) {
+        Objects.requireNonNull(level, "Must not log a null level");
+        // we double-check (here and in #route) to avoid expensive locking on the happy path
+        if (!isInitialized() && STARTUP_ROUTER.route(KNIMELogger::isInitialized, level, m_name, message, cause)) {
+            return;
         }
         m_logger.log(level, message, omitContext, cause);
     }

--- a/org.knime.core/src/eclipse/org/knime/core/node/logging/LogBuffer.java
+++ b/org.knime.core/src/eclipse/org/knime/core/node/logging/LogBuffer.java
@@ -52,13 +52,15 @@ import java.time.Instant;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.function.Consumer;
 
 import org.apache.commons.collections.buffer.BoundedFifoBuffer;
 import org.apache.log4j.Level;
 
 /**
- * Simple fixed-size buffer of log messages. This class is <b>not thread-safe</b>.
+ * Simple fixed-size circular buffer for log messages.
+ *
+ * <p><strong>This class is not thread-safe.</strong> Callers must ensure that concurrent {@link #add} calls and calls
+ * to {@link #drain} do not overlap.
  *
  * @author Manuel Hotz, KNIME GmbH, Konstanz, Germany
  */
@@ -66,13 +68,9 @@ final class LogBuffer {
 
     private final CircularFiFoBuffer m_logBuffer;
 
-    LogBuffer(final int bufferSize) {
-        m_logBuffer = new CircularFiFoBuffer(bufferSize);
-    }
-
     /**
-     * Buffered log message for storage until the logging system is initialized and log messages can be written
-     * to their intended location based on user configuration.
+     * Buffered log message for storage until the logging system is initialized and log messages can be written to their
+     * intended location based on user configuration.
      *
      * @param instant instant the log message was buffered
      * @param name name of the logger (e.g. the class name)
@@ -82,8 +80,23 @@ final class LogBuffer {
      *
      * @author Manuel Hotz, KNIME GmbH, Konstanz, Germany
      */
-    record BufferedLogMessage(Instant instant, String name, Level level, Object message,
-        Throwable cause) { }
+    record BufferedLogMessage(Instant instant, String name, Level level, Object message, Throwable cause) {
+    }
+
+    /**
+     * The result of draining the buffer. The caller exclusively owns the entries after {@link LogBuffer#drain()}
+     * returns.
+     *
+     * @param messages iterator over the buffered entries in insertion order
+     * @param evictedEntries number of entries evicted over the lifetime of the buffer
+     * @param total total number of entries that passed through the buffer (buffered + evicted)
+     * @param evictionMessageLevel most severe level among evicted entries, at least {@link Level#WARN}
+     *
+     * @author Manuel Hotz, KNIME GmbH, Konstanz, Germany
+     */
+    record DrainResult(Iterator<BufferedLogMessage> messages, long evictedEntries, long total,
+        Level evictionMessageLevel) {
+    }
 
     /**
      * Ring buffer with fixed capacity that evicts the least recently inserted entry.
@@ -93,7 +106,8 @@ final class LogBuffer {
     private static final class CircularFiFoBuffer {
 
         private long m_evicted;
-        private final BoundedFifoBuffer m_delegate;
+
+        private BoundedFifoBuffer m_delegate;
 
         /**
          * Level used for log message informing the user that some log messages were evicted.
@@ -110,12 +124,10 @@ final class LogBuffer {
         }
 
         /**
-         * Adds the given entry to the buffer, indicating if another entry was evicted to make room for the
-         * given one.
+         * Adds the given entry to the buffer, indicating if another entry was evicted to make room for the given one.
          *
          * @param entry entry to buffer
-         * @return {@code true} if another entry was evicted in order to add the given entry,
-         *     {@code false} otherwise
+         * @return {@code true} if another entry was evicted in order to add the given entry, {@code false} otherwise
          */
         boolean add(final BufferedLogMessage entry) {
             var didEvict = false;
@@ -136,6 +148,7 @@ final class LogBuffer {
 
         /**
          * Returns the number of evicted entries during the lifetime of this buffer.
+         *
          * @return number of evicted entries
          */
         long getNumberOfEvictedEntries() {
@@ -144,6 +157,7 @@ final class LogBuffer {
 
         /**
          * Checks whether the buffer is empty or not.
+         *
          * @return {@code true} if the buffer is empty, {@code false} otherwise
          */
         boolean isEmpty() {
@@ -151,19 +165,22 @@ final class LogBuffer {
         }
 
         /**
-         * Returns an iterator over the entries in the buffer, draining it in the process.
+         * Transfers ownership of all currently buffered entries to a detached iterator.
          * <p>
-         * <b>Note:</b> this method is <i>not thread-safe</i>.
-         *     Therefore, you have to synchronize over the parent object.
+         * After this call, the delegate is set to {@code null}: the buffer must not be used further.
          *
-         * @return draining iterator over contained entries in insertion order (from least recently inserted to
-         *     most recently inserted)
+         * @return iterator over the detached buffered entries in insertion order
          */
-        Iterator<BufferedLogMessage> drainingIterator() {
+        private Iterator<BufferedLogMessage> transferEntries() {
+            final var detachedEntries = m_delegate;
+            m_delegate = null;
             return new Iterator<BufferedLogMessage>() {
+                @SuppressWarnings("unchecked")
+                private final Iterator<BufferedLogMessage> m_iterator = detachedEntries.iterator();
+
                 @Override
                 public boolean hasNext() {
-                    return !m_delegate.isEmpty();
+                    return m_iterator.hasNext();
                 }
 
                 @Override
@@ -171,7 +188,7 @@ final class LogBuffer {
                     if (!hasNext()) {
                         throw new NoSuchElementException();
                     }
-                    return (BufferedLogMessage)m_delegate.remove();
+                    return m_iterator.next();
                 }
             };
         }
@@ -181,43 +198,48 @@ final class LogBuffer {
         }
     }
 
-    /**
-     * Drain the buffer to the given consumer. If the buffer evicted any messages, a warning message will be logged.
-     *
-     * @param consumer consumer for buffered log messages
-     */
-    void drainTo(final Consumer<BufferedLogMessage> consumer) {
-        if (!m_logBuffer.isEmpty()) {
-            // we expect no NodeContext to be available at this point anyway
-            final var omitCtx = true;
-            final var logger = KNIMELogger.getLogger(KNIMELogger.class);
-            final var current = m_logBuffer.size();
-            final var evicted = m_logBuffer.getNumberOfEvictedEntries();
-            final var total = current + evicted;
-            final var countMessages = total > 1 ? "%d messages were".formatted(total) : "1 message was";
-            logger.log(Level.DEBUG, () -> "%s logged before logging was initialized; see below..."
-                .formatted(countMessages), omitCtx, null);
-            if (evicted > 0) {
-                logger.log(m_logBuffer.m_levelForEvictionMessage,
-                    () -> "[*** Log incomplete: log buffer did wrap around -- "
-                            + "%d messages were evicted from buffer in total ***]".formatted(evicted), omitCtx, null);
-            }
-            m_logBuffer.drainingIterator().forEachRemaining(consumer);
-            logger.log(Level.DEBUG, "End of buffered log messages", omitCtx, null);
-        }
+    LogBuffer(final int bufferSize) {
+        m_logBuffer = new CircularFiFoBuffer(bufferSize);
     }
 
     /**
-     * Buffer the given message at the given level under the given logger name.
+     * Adds a log message to the buffer.
      *
      * @param level level to log at
      * @param name logger name to log under
      * @param msg message to log
      * @param cause {@code null}-able cause for the message
      */
-    void log(final Level level, final String name, final Object msg, final Throwable cause) {
+    void add(final Level level, final String name, final Object msg, final Throwable cause) {
         m_logBuffer.add(new BufferedLogMessage(Instant.now(), Objects.requireNonNull(name),
             Objects.requireNonNull(level), Objects.requireNonNullElse(msg, ""), cause));
+    }
+
+    /**
+     * Checks whether the buffer is currently empty.
+     *
+     * @return {@code true} if the buffer is empty, {@code false} otherwise
+     */
+    boolean isEmpty() {
+        return m_logBuffer.isEmpty();
+    }
+
+    /**
+     * Transfers ownership of all buffered entries to the caller.
+     * <p>
+     * <strong>After this call, this buffer must not be used for further {@link #add} calls.</strong> The caller is
+     * responsible for ensuring no concurrent {@link #add} calls are in progress when this method is invoked.
+     *
+     * @return drain result holding the buffered entries, or {@code null} if the buffer is empty
+     */
+    DrainResult drain() {
+        if (m_logBuffer.isEmpty()) {
+            return null;
+        }
+        final var evictedEntries = m_logBuffer.getNumberOfEvictedEntries();
+        final var total = m_logBuffer.size() + evictedEntries;
+        return new DrainResult(m_logBuffer.transferEntries(), evictedEntries, total,
+            m_logBuffer.m_levelForEvictionMessage);
     }
 
 }

--- a/org.knime.core/src/eclipse/org/knime/core/node/logging/StartupLogRouter.java
+++ b/org.knime.core/src/eclipse/org/knime/core/node/logging/StartupLogRouter.java
@@ -1,0 +1,385 @@
+/*
+ * ------------------------------------------------------------------------
+ *
+ *  Copyright by KNIME AG, Zurich, Switzerland
+ *  Website: http://www.knime.com; Email: contact@knime.com
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License, Version 3, as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ *  Additional permission under GNU GPL version 3 section 7:
+ *
+ *  KNIME interoperates with ECLIPSE solely via ECLIPSE's plug-in APIs.
+ *  Hence, KNIME and ECLIPSE are both independent programs and are not
+ *  derived from each other. Should, however, the interpretation of the
+ *  GNU GPL Version 3 ("License") under any applicable laws result in
+ *  KNIME and ECLIPSE being a combined program, KNIME AG herewith grants
+ *  you the additional permission to use and propagate KNIME together with
+ *  ECLIPSE with only the license terms in place for ECLIPSE applying to
+ *  ECLIPSE and the GNU GPL Version 3 applying for KNIME, provided the
+ *  license terms of ECLIPSE themselves allow for the respective use and
+ *  propagation of ECLIPSE together with KNIME.
+ *
+ *  Additional permission relating to nodes for KNIME that extend the Node
+ *  Extension (and in particular that are based on subclasses of NodeModel,
+ *  NodeDialog, and NodeView) and that only interoperate with KNIME through
+ *  standard APIs ("Nodes"):
+ *  Nodes are deemed to be separate and independent programs and to not be
+ *  covered works.  Notwithstanding anything to the contrary in the
+ *  License, the License does not apply to Nodes, you are not required to
+ *  license Nodes under the License, and you are granted a license to
+ *  prepare and propagate Nodes, in each case even if such Nodes are
+ *  propagated with or for interoperation with KNIME.  The owner of a Node
+ *  may freely choose the license terms applicable to such Node, including
+ *  when such Node is propagated with or for interoperation with KNIME.
+ * ---------------------------------------------------------------------
+ *
+ * History
+ *   24 Mar 2026 (Manuel Hotz, KNIME GmbH, Konstanz, Germany): created
+ */
+package org.knime.core.node.logging;
+
+import java.io.PrintStream;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.apache.log4j.Layout;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.knime.core.node.NodeLoggerPatternLayout;
+import org.knime.core.node.logging.LogBuffer.BufferedLogMessage;
+
+/**
+ * Routes pre-initialization log messages: buffers until the logging system is initialized (normal path), or emits to a
+ * configurable output stream when the JVM shuts down before initialization completes (failsafe path).
+ *
+ * <h2>Ownership</h2>
+ * <p>
+ * This class exclusively owns the {@link LogBuffer} it was constructed with. No other code may access the buffer
+ * directly. Ownership of buffered entries is transferred to the consumer passed to {@link #drainToLogger}, or to this
+ * class during {@link #activateFailsafeAndDrain()}.
+ *
+ * <h2>Routing state</h2>
+ * <p>
+ * Starts in {@link Target#BUFFER} state. Transitions to {@link Target#FAILSAFE} at most once, via
+ * {@link #activateFailsafeAndDrain()}.
+ * <p>
+ *
+ * @author Manuel Hotz, KNIME GmbH, Konstanz, Germany
+ */
+final class StartupLogRouter {
+
+    /**
+     * Environment variable controlling where the logging failsafe output is written. Values: "stderr"
+     * (case-insensitive) for {@code stderr}, anything else (including if not set) for {@code stdout}.
+     */
+    private static final String ENV_LOGGING_FAILSAFE_TARGET = "KNIME_CORE_LOGGING_FAILSAFE_TARGET";
+
+    /**
+     * Environment variable controlling the minimum level written by the logging failsafe output. Values: any valid
+     * Log4j 1 level name (case-insensitive), e.g. "INFO". Defaults to "DEBUG" if not set or invalid.
+     */
+    private static final String ENV_LOGGING_FAILSAFE_MIN_LEVEL = "KNIME_CORE_LOGGING_FAILSAFE_MIN_LEVEL";
+
+    private enum Target {
+            /** Log messages are buffered in {@link #m_buffer}. */
+            BUFFER,
+            /** Log messages are emitted directly to {@link #m_failsafeOut}. */
+            FAILSAFE
+    }
+
+    // The log buffer is exclusively owned by this instance. All access must be preceded by acquiring this instance's
+    // monitor, except after m_isDrained is set. At that point the buffer's contents are owned by the drainer.
+    private final LogBuffer m_buffer;
+
+    // Immutable after construction
+    private final PrintStream m_failsafeOut;
+
+    private final Level m_failsafeMinLevel;
+
+    private final Layout m_failsafeLayout;
+
+    private final AtomicBoolean m_isShutdownHookInstalled = new AtomicBoolean();
+
+    /* Both {@code m_target} and {@code m_isDrained} are guarded by this instance's monitor and must only be read or
+     * written while holding it.
+     */
+    // The routing target specifies where to route incoming log messages to. It transitions BUFFER→FAILSAFE at most
+    // once (in activateFailsafeAndDrain). Is guarded by this instance's monitor.
+    private Target m_target = Target.BUFFER;
+
+    // The flag is {@code true} once the buffer's contents have been transferred out (to logger or to failsafe output).
+    // After this is set, no further LogBuffer#add calls are made. Is guarded by this instance's monitor.
+    private boolean m_isDrained;
+
+    @SuppressWarnings("resource") // no ownership over System streams
+    StartupLogRouter(final int bufferSize) {
+        this(bufferSize, initFailsafeTarget(), initFailsafeMinLevel(), initFailsafeLayout());
+    }
+
+    StartupLogRouter(final int bufferSize, final PrintStream failsafeOut, final Level failsafeMinLevel,
+        final Layout failsafeLayout) {
+        m_buffer = new LogBuffer(bufferSize);
+        m_failsafeOut = failsafeOut;
+        m_failsafeMinLevel = failsafeMinLevel;
+        m_failsafeLayout = failsafeLayout;
+    }
+
+    /**
+     * Routes a pre-initialization log message.
+     * <p>
+     * In {@link Target#BUFFER} state, the message is added to the buffer (unless already drained). In
+     * {@link Target#FAILSAFE} state, the message is emitted directly to the failsafe output if it meets the minimum
+     * level.
+     *
+     * @param isInitialized supplier for whether the logging system is already initialized
+     * @param level level to log at
+     * @param name logger name
+     * @param message message to log
+     * @param cause {@code null}-able cause
+     * @return {@code true} if the message was handled; {@code false} if the caller should forward it to the logging
+     *         framework
+     */
+    boolean route(final BooleanSupplier isInitialized, final Level level, final String name, final Object message,
+        final Throwable cause) {
+        // double-checked locking to avoid lock contention on happy path after initialization
+        if (isInitialized.getAsBoolean()) {
+            return false;
+        }
+        installShutdownHookIfNeeded();
+        synchronized (this) {
+            if (isInitialized.getAsBoolean()) {
+                return false;
+            }
+            if (m_target == Target.BUFFER) {
+                if (m_isDrained) {
+                    return false;
+                }
+                m_buffer.add(level, name, message, cause);
+                return true;
+            }
+            // Target.FAILSAFE: release the lock before doing I/O
+        }
+        if (level.isGreaterOrEqual(m_failsafeMinLevel)) {
+            emitToFailsafe(name, level, message, cause, Instant.now());
+        }
+        return true;
+    }
+
+    /**
+     * Routes a pre-initialization log message with a lazy message supplier.
+     * <p>
+     * The supplier is evaluated inside the synchronized block in {@link Target#BUFFER} state, or outside it (only if
+     * the level meets the minimum threshold) in {@link Target#FAILSAFE} state.
+     *
+     * @param isInitialized supplier for whether the logging system is already initialized
+     * @param level level to log at
+     * @param name logger name
+     * @param messageSupplier supplier for the message
+     * @param cause {@code null}-able cause
+     * @return {@code true} if the message was handled; {@code false} if the caller should forward it to the logging
+     *         framework
+     */
+    boolean route(final BooleanSupplier isInitialized, final Level level, final String name,
+        final Supplier<Object> messageSupplier, final Throwable cause) {
+        // double-checked locking to avoid lock contention on happy path after initialization
+        if (isInitialized.getAsBoolean()) {
+            return false;
+        }
+        installShutdownHookIfNeeded();
+        synchronized (this) {
+            if (isInitialized.getAsBoolean()) {
+                return false;
+            }
+            if (m_target == Target.BUFFER) {
+                if (m_isDrained) {
+                    return false;
+                }
+                m_buffer.add(level, name, messageSupplier.get(), cause);
+                return true;
+            }
+            // Target.FAILSAFE: release the lock before evaluating the supplier or doing I/O
+        }
+        if (level.isGreaterOrEqual(m_failsafeMinLevel)) {
+            emitToFailsafe(name, level, messageSupplier.get(), cause, Instant.now());
+        }
+        return true;
+    }
+
+    /**
+     * Drains the buffer to the given consumer. Must only be called after the logging system is initialized.
+     * <p>
+     * Ownership of the buffered entries is transferred to the consumer. This method is idempotent: subsequent calls
+     * after the first have no effect.
+     * <p>
+     * <em>Lock ordering:</em> callers may hold an outer lock (e.g. {@code KNIMELogger.class}) when invoking this
+     * method. This method acquires {@code StartupLogRouter.this} internally, then releases it before any further calls.
+     * No code inside this class ever acquires an outer lock while holding {@code StartupLogRouter.this}, so the
+     * ordering is always outer → {@code StartupLogRouter.this}, preventing deadlocks.
+     *
+     * @param consumer consumer for each buffered log message
+     */
+    void drainToLogger(final Consumer<BufferedLogMessage> consumer) {
+        final LogBuffer.DrainResult drainResult;
+        synchronized (this) {
+            if (m_isDrained) {
+                return;
+            }
+            m_isDrained = true;
+            drainResult = m_buffer.drain();
+        }
+        if (drainResult == null) {
+            return;
+        }
+        final var omitCtx = true;
+        final var logger = KNIMELogger.getLogger(KNIMELogger.class);
+        final var count = formatMessageCount(drainResult.total());
+        logger.log(Level.DEBUG, () -> "%s logged before logging was initialized; see below...".formatted(count),
+            omitCtx, null);
+        if (drainResult.evictedEntries() > 0) {
+            logger.log(drainResult.evictionMessageLevel(), () -> formatEvictionNotice(drainResult.evictedEntries()),
+                omitCtx, null);
+        }
+        drainResult.messages().forEachRemaining(consumer);
+        logger.log(Level.DEBUG, "End of buffered log messages", omitCtx, null);
+    }
+
+    /**
+     * Transitions to {@link Target#FAILSAFE} state and drains any buffered messages to the failsafe output.
+     * <p>
+     * After this call, any new uninitialized log messages are emitted directly to the failsafe output (subject to the
+     * configured minimum level). This method is idempotent: if already in failsafe state, it returns immediately.
+     * <p>
+     * If the buffer was already drained to the logger (normal path), the transition to failsafe still occurs so that
+     * any subsequent messages are routed correctly, but there is nothing to emit.
+     */
+    void activateFailsafeAndDrain() {
+        final LogBuffer.DrainResult drainResult;
+        synchronized (this) {
+            if (m_target == Target.FAILSAFE) {
+                return;
+            }
+            m_target = Target.FAILSAFE;
+            if (m_isDrained) {
+                // Buffer was already drained to the logger; nothing to emit to failsafe
+                return;
+            }
+            m_isDrained = true;
+            drainResult = m_buffer.drain();
+        }
+        if (drainResult == null) {
+            return;
+        }
+
+        final var shouldEmitEvictionNotice =
+            drainResult.evictedEntries() > 0 && drainResult.evictionMessageLevel().isGreaterOrEqual(m_failsafeMinLevel);
+
+        final var count = formatMessageCount(drainResult.total());
+        final var reason = "JVM is shutting down before KNIME logging could finish initialization";
+        final Runnable notice =
+            () -> m_failsafeOut.printf("--- KNIME startup failsafe logging dump: %s. %s buffered. Minimum level: %s.%n",
+                reason, count, m_failsafeMinLevel);
+
+        var didEmitAnything = false;
+        if (shouldEmitEvictionNotice) {
+            notice.run();
+            emitToFailsafe(KNIMELogger.class.getName(), drainResult.evictionMessageLevel(),
+                formatEvictionNotice(drainResult.evictedEntries()), null, Instant.now());
+            didEmitAnything = true;
+        }
+
+        final var messages = drainResult.messages();
+        while (messages.hasNext()) {
+            final var message = messages.next();
+            if (!message.level().isGreaterOrEqual(m_failsafeMinLevel)) {
+                continue;
+            }
+            if (!didEmitAnything) {
+                notice.run();
+                didEmitAnything = true;
+            }
+            emitToFailsafe(message.name(), message.level(), message.message(), message.cause(), message.instant());
+        }
+
+        if (didEmitAnything) {
+            m_failsafeOut.println("--- End of KNIME startup failsafe logging dump.");
+            m_failsafeOut.flush();
+        }
+    }
+
+    private void installShutdownHookIfNeeded() {
+        if (!m_isShutdownHookInstalled.get() && m_isShutdownHookInstalled.compareAndSet(false, true)) {
+            try {
+                Runtime.getRuntime()
+                    .addShutdownHook(new Thread(this::activateFailsafeAndDrain, "KNIME startup log dump"));
+            } catch (IllegalStateException ex) { // NOSONAR: failsafe path cannot rely on regular logging here
+                emitToFailsafe(KNIMELogger.class.getName(), Level.WARN,
+                    "Unable to register KNIME startup log shutdown hook because JVM shutdown is already in progress."
+                        + " Buffered startup log messages may follow now.",
+                    ex, Instant.now());
+                activateFailsafeAndDrain();
+            }
+        }
+    }
+
+    private static String formatMessageCount(final long total) {
+        return total > 1 ? "%d messages were".formatted(total) : "1 message was";
+    }
+
+    private static String formatEvictionNotice(final long evictedEntries) {
+        return "[*** Log incomplete: log buffer did wrap around -- "
+            + "%d messages were evicted from buffer in total ***]".formatted(evictedEntries);
+    }
+
+    private void emitToFailsafe(final String name, final Level level, final Object message, final Throwable cause,
+        final Instant instant) {
+        final var event = new LoggingEvent(KNIMELogger.class.getName(), Logger.getLogger(name), instant.toEpochMilli(),
+            level, message, cause);
+        m_failsafeOut.print(m_failsafeLayout.format(event));
+        if (cause != null && m_failsafeLayout.ignoresThrowable()) {
+            cause.printStackTrace(m_failsafeOut);
+        }
+        m_failsafeOut.flush();
+    }
+
+    private static PrintStream initFailsafeTarget() {
+        final var configuredTarget = System.getenv(ENV_LOGGING_FAILSAFE_TARGET);
+        // do not involve another logging framework, that's the whole point of this failsafe
+        return "stderr".equalsIgnoreCase(configuredTarget) ? System.err : System.out; // NOSONAR see comment above
+    }
+
+    private static Level initFailsafeMinLevel() {
+        return Level.toLevel(System.getenv(ENV_LOGGING_FAILSAFE_MIN_LEVEL), Level.DEBUG);
+    }
+
+    /**
+     * Creates the default failsafe layout.
+     * <p>
+     * The pattern {@code %d{ISO8601} : %-5p : %t : %c{1} : %m%n} mirrors the structure of the default KNIME logfile
+     * appender pattern. The KNIME-specific node-context fields ({@code %N}, {@code %I}, {@code %J}) present in the
+     * regular log pattern are omitted; they are always empty during startup so the output is equivalent. Example:
+     * <pre>
+     * 2026-03-26 10:15:30,123 : INFO  : main : KNIMELogger : Startup message
+     * </pre>
+     */
+    private static Layout initFailsafeLayout() {
+        final var layout = new NodeLoggerPatternLayout();
+        layout.setConversionPattern("%d{ISO8601} : %-5p : %t : %c{1} : %m%n");
+        layout.activateOptions();
+        return layout;
+    }
+
+}


### PR DESCRIPTION
AP-25788 (NodeLogger may swallow buffered log messages)