### PR TITLE
AP-25813: Drain startup log buffer after log levels are configured

### DIFF
--- a/org.knime.core/plugin.xml
+++ b/org.knime.core/plugin.xml
@@ -827,6 +827,10 @@
       </provider>
       <provider
             startupStage="BEFORE_WFM_CLASS_LOADED"
+            class="org.knime.core.node.logging.KNIMELogger$EarlyStartupMessageForwarder">
+      </provider>
+      <provider
+            startupStage="BEFORE_WFM_CLASS_LOADED"
             class="org.knime.core.eclipseUtil.URLConnectionCacheDisabler">
       </provider>
       <provider

--- a/org.knime.core/src/eclipse/org/knime/core/node/logging/KNIMELogger.java
+++ b/org.knime.core/src/eclipse/org/knime/core/node/logging/KNIMELogger.java
@@ -183,13 +183,30 @@ import org.knime.core.util.Pair;
 public final class KNIMELogger {
 
     /**
-     * This initializer is registered via the {@link IEarlyStartup} extension point at stage
+     * Initializes the logging framework. Registered via the {@link IEarlyStartup} extension point at stage
      * {@link org.knime.core.util.IEarlyStartup.StartupStage#AFTER_PROFILES_SET AFTER_PROFILES_SET}.
+     * <p>
+     * The buffer drain is intentionally deferred to {@link EarlyStartupMessageForwarder}, which runs at
+     * {@link org.knime.core.util.IEarlyStartup.StartupStage#BEFORE_WFM_CLASS_LOADED BEFORE_WFM_CLASS_LOADED}, after
+     * operator-configured log levels (env vars, customization profile preferences) have been applied.
      */
     public static final class EarlyStartupInitializer implements IEarlyStartup {
         @Override
         public void run() {
-            initializeLogging(true);
+            initializeLogging(false);
+        }
+    }
+
+    /**
+     * Drains the startup log buffer into the configured logging framework. Registered via the {@link IEarlyStartup}
+     * extension point at stage
+     * {@link org.knime.core.util.IEarlyStartup.StartupStage#BEFORE_WFM_CLASS_LOADED BEFORE_WFM_CLASS_LOADED}, after
+     * operator-configured log levels have been applied.
+     */
+    public static final class EarlyStartupMessageForwarder implements IEarlyStartup {
+        @Override
+        public void run() {
+            logBufferedMessages();
         }
     }
 
@@ -974,8 +991,13 @@ public final class KNIMELogger {
 
     /**
      * Logs any buffered messages. Will throw an exception if still in uninitialized state.
+     * <p>
+     * Synchronized on {@code KNIMELogger.class} to serialize with {@link #initializeLogging}: a concurrent shutdown
+     * hook calling this method before {@link #initializeLogging} has finished populating {@link #LOGGERS} would
+     * otherwise encounter {@code KNIMELogger} instances whose {@code m_logger} field is still {@code null}.
+     * {@link #drainToLogger} is idempotent, so concurrent calls are safe.
      */
-    static void logBufferedMessages() {
+    static synchronized void logBufferedMessages() {
         checkInitializedState();
         STARTUP_ROUTER.drainToLogger(bufferedMessage -> getLogger(bufferedMessage.name()).log(bufferedMessage));
     }

--- a/org.knime.core/src/eclipse/org/knime/core/node/logging/StartupLogRouter.java
+++ b/org.knime.core/src/eclipse/org/knime/core/node/logging/StartupLogRouter.java
@@ -323,8 +323,16 @@ final class StartupLogRouter {
     private void installShutdownHookIfNeeded() {
         if (!m_isShutdownHookInstalled.get() && m_isShutdownHookInstalled.compareAndSet(false, true)) {
             try {
-                Runtime.getRuntime()
-                    .addShutdownHook(new Thread(this::activateFailsafeAndDrain, "KNIME startup log dump"));
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                    if (KNIMELogger.isInitialized()) {
+                        // Logging is configured: drain through the real appenders so configured levels are respected.
+                        // logBufferedMessages() is synchronized on KNIMELogger.class, so if initializeLogging() is
+                        // still running we block until all KNIMELogger instances have their m_logger set.
+                        KNIMELogger.logBufferedMessages();
+                    } else {
+                        activateFailsafeAndDrain();
+                    }
+                }, "KNIME startup log dump"));
             } catch (IllegalStateException ex) { // NOSONAR: failsafe path cannot rely on regular logging here
                 emitToFailsafe(KNIMELogger.class.getName(), Level.WARN,
                     "Unable to register KNIME startup log shutdown hook because JVM shutdown is already in progress."


### PR DESCRIPTION
Split EarlyStartupInitializer into two stages: init only at AFTER_PROFILES_SET, and buffer drain at BEFORE_WFM_CLASS_LOADED. This ensures env-var and profile-preference log levels are applied before buffered startup messages are forwarded to the appenders.

Also makes logBufferedMessages() synchronized to prevent an NPE race between initializeLogging() and a concurrent shutdown hook, and updates the shutdown hook to drain via the configured logging framework when already initialized.
AP-25813 (Early startup log messages respect configured appender log levels)