### PR TITLE
AP-25788: Failsafe logging only enabled by default for AP and Executor

### DIFF
--- a/org.knime.core.tests/src/org/knime/core/node/logging/KNIMELoggerTest.java
+++ b/org.knime.core.tests/src/org/knime/core/node/logging/KNIMELoggerTest.java
@@ -50,6 +50,7 @@ package org.knime.core.node.logging;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -68,6 +69,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.knime.core.node.NodeLogger;
 import org.knime.core.node.NodeLogger.LEVEL;
+import org.knime.core.util.EclipseUtil;
 import org.knime.core.util.Pair;
 
 /**
@@ -301,6 +303,76 @@ class KNIMELoggerTest {
         assertFalse(dump.contains("evicted"), "Expected no eviction notice without overflow");
         assertTrue(dump.contains("first"), "Expected first message in dump");
         assertTrue(dump.contains("second"), "Expected second message in dump");
+    }
+
+    @Test
+    void testResolveFailsafeTargetOffDisablesFailsafe() {
+        assertNull(StartupLogRouter.resolveFailsafeTarget("off", EclipseUtil.Application.AP),
+            "Expected null for \"off\" (AP)");
+        assertNull(StartupLogRouter.resolveFailsafeTarget("OFF", EclipseUtil.Application.EXECUTOR),
+            "Expected null for \"OFF\" (EXECUTOR)");
+        assertNull(StartupLogRouter.resolveFailsafeTarget("Off", EclipseUtil.Application.UNKNOWN),
+            "Expected null for \"Off\" (UNKNOWN)");
+    }
+
+    @Test
+    void testResolveFailsafeTargetStderrWritesToStderr() {
+        assertEquals(System.err, StartupLogRouter.resolveFailsafeTarget("stderr", EclipseUtil.Application.UNKNOWN),
+            "Expected System.err for \"stderr\"");
+        assertEquals(System.err, StartupLogRouter.resolveFailsafeTarget("STDERR", EclipseUtil.Application.UNKNOWN),
+            "Expected System.err for \"STDERR\" (case-insensitive)");
+    }
+
+    @Test
+    void testResolveFailsafeTargetStdoutWritesToStdout() {
+        assertEquals(System.out, StartupLogRouter.resolveFailsafeTarget("stdout", EclipseUtil.Application.UNKNOWN),
+            "Expected System.out for \"stdout\"");
+        assertEquals(System.out, StartupLogRouter.resolveFailsafeTarget("any-other-value", EclipseUtil.Application.UNKNOWN),
+            "Expected System.out for any non-special non-blank value");
+    }
+
+    @Test
+    void testResolveFailsafeTargetNullEnablesDefaultByApplication() {
+        // enabled by default for AP and EXECUTOR
+        assertEquals(System.out, StartupLogRouter.resolveFailsafeTarget(null, EclipseUtil.Application.AP),
+            "Expected System.out by default for AP");
+        assertEquals(System.out, StartupLogRouter.resolveFailsafeTarget(null, EclipseUtil.Application.EXECUTOR),
+            "Expected System.out by default for EXECUTOR");
+        // disabled by default for all other applications
+        assertNull(StartupLogRouter.resolveFailsafeTarget(null, EclipseUtil.Application.WARMSTART),
+            "Expected null (disabled) by default for WARMSTART");
+    }
+
+    @Test
+    void testResolveFailsafeTargetBlankEnablesDefaultByApplication() {
+        // blank is treated the same as unset: enabled for AP and EXECUTOR, disabled for others
+        assertEquals(System.out, StartupLogRouter.resolveFailsafeTarget("", EclipseUtil.Application.AP),
+            "Expected System.out for blank value with AP");
+        assertEquals(System.out, StartupLogRouter.resolveFailsafeTarget("  ", EclipseUtil.Application.EXECUTOR),
+            "Expected System.out for whitespace-only value with EXECUTOR");
+        assertNull(StartupLogRouter.resolveFailsafeTarget("", EclipseUtil.Application.WARMSTART),
+            "Expected null (disabled) for blank value with WARMSTART");
+    }
+
+    @Test
+    void testFailsafeDisabledProducesNoOutput() {
+        final var router = new StartupLogRouter(2, null, Level.DEBUG, createFailsafeLayout());
+        router.route(() -> false, Level.ERROR, LOGGER_NAME, "message", null);
+        router.activateFailsafeAndDrain(); // no-op: failsafe is disabled
+        // message is still in the buffer since the disabled failsafe did not drain it
+        final var wasDrained = new AtomicBoolean();
+        router.drainToLogger(m -> wasDrained.set(true));
+        assertTrue(wasDrained.get(), "Expected message to remain buffered after disabled failsafe");
+    }
+
+    @Test
+    void testFailsafeDisabledDoesNotDrainBuffer() {
+        final var router = new StartupLogRouter(2, null, Level.DEBUG, createFailsafeLayout());
+        router.route(() -> false, Level.WARN, LOGGER_NAME, "first", null);
+        router.activateFailsafeAndDrain(); // no-op when disabled
+        // buffer is still in BUFFER state, so further route() calls still buffer
+        assertTrue(router.route(() -> false, Level.ERROR, LOGGER_NAME, "second", null),
+            "Expected route() to still buffer messages after disabled failsafe activation");
     }
 
     private static Layout createFailsafeLayout() {

--- a/org.knime.core/src/eclipse/org/knime/core/node/logging/KNIMELogger.java
+++ b/org.knime.core/src/eclipse/org/knime/core/node/logging/KNIMELogger.java
@@ -158,8 +158,16 @@ import org.knime.core.util.Pair;
  * stream (the <em>failsafe</em> path) so that startup log messages are not silently lost. Two environment variables
  * control this behaviour:
  * <ul>
- *   <li>{@code KNIME_CORE_LOGGING_FAILSAFE_TARGET} — output target: {@code stderr} (case-insensitive) writes to
- *       {@code stderr}; any other value (or unset) writes to {@code stdout}.</li>
+ *   <li>{@code KNIME_CORE_LOGGING_FAILSAFE_TARGET} — output target:
+ *     <ul>
+ *       <li>{@code stderr} (case-insensitive) — writes to {@code stderr}</li>
+ *       <li>{@code stdout} (case-insensitive) or any other non-empty value — writes to {@code stdout}</li>
+ *       <li>{@code off} (case-insensitive) — disables the failsafe</li>
+ *       <li>unset — enabled by default for {@link org.knime.core.util.EclipseUtil.Application#AP AP} and
+ *           {@link org.knime.core.util.EclipseUtil.Application#EXECUTOR EXECUTOR} applications (writing to
+ *           {@code stdout}); disabled for all other applications</li>
+ *     </ul>
+ *   </li>
  *   <li>{@code KNIME_CORE_LOGGING_FAILSAFE_MIN_LEVEL} — minimum log level emitted to the failsafe output; any
  *       valid Log4j&nbsp;1 level name (case-insensitive), e.g. {@code INFO}. Defaults to {@code DEBUG} if unset
  *       or unrecognised.</li>

--- a/org.knime.core/src/eclipse/org/knime/core/node/logging/StartupLogRouter.java
+++ b/org.knime.core/src/eclipse/org/knime/core/node/logging/StartupLogRouter.java
@@ -61,6 +61,7 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
 import org.knime.core.node.NodeLoggerPatternLayout;
 import org.knime.core.node.logging.LogBuffer.BufferedLogMessage;
+import org.knime.core.util.EclipseUtil;
 
 /**
  * Routes pre-initialization log messages: buffers until the logging system is initialized (normal path), or emits to a
@@ -83,8 +84,16 @@ import org.knime.core.node.logging.LogBuffer.BufferedLogMessage;
 final class StartupLogRouter {
 
     /**
-     * Environment variable controlling where the logging failsafe output is written. Values: "stderr"
-     * (case-insensitive) for {@code stderr}, anything else (including if not set) for {@code stdout}.
+     * Environment variable controlling where the logging failsafe output is written.
+     * <ul>
+     *   <li>{@code stderr} (case-insensitive) — writes to {@code stderr}</li>
+     *   <li>{@code stdout} (case-insensitive) — writes to {@code stdout}</li>
+     *   <li>{@code off} (case-insensitive) — disables the failsafe</li>
+     *   <li>any other non-empty value — writes to {@code stdout}</li>
+     *   <li>unset or blank — enabled by default for {@link EclipseUtil.Application#AP} and
+     *       {@link EclipseUtil.Application#EXECUTOR} (writing to {@code stdout}); disabled for all other
+     *       applications</li>
+     * </ul>
      */
     private static final String ENV_LOGGING_FAILSAFE_TARGET = "KNIME_CORE_LOGGING_FAILSAFE_TARGET";
 
@@ -105,7 +114,7 @@ final class StartupLogRouter {
     // monitor, except after m_isDrained is set. At that point the buffer's contents are owned by the drainer.
     private final LogBuffer m_buffer;
 
-    // Immutable after construction
+    // null if disabled
     private final PrintStream m_failsafeOut;
 
     private final Level m_failsafeMinLevel;
@@ -267,6 +276,9 @@ final class StartupLogRouter {
      * any subsequent messages are routed correctly, but there is nothing to emit.
      */
     void activateFailsafeAndDrain() {
+        if (m_failsafeOut == null) {
+            return; // failsafe is disabled
+        }
         final LogBuffer.DrainResult drainResult;
         synchronized (this) {
             if (m_target == Target.FAILSAFE) {
@@ -321,6 +333,9 @@ final class StartupLogRouter {
     }
 
     private void installShutdownHookIfNeeded() {
+        if (m_failsafeOut == null) {
+            return; // failsafe is disabled
+        }
         if (!m_isShutdownHookInstalled.get() && m_isShutdownHookInstalled.compareAndSet(false, true)) {
             try {
                 Runtime.getRuntime()
@@ -355,10 +370,34 @@ final class StartupLogRouter {
         m_failsafeOut.flush();
     }
 
+    @SuppressWarnings("resource") // no ownership over System streams
     private static PrintStream initFailsafeTarget() {
-        final var configuredTarget = System.getenv(ENV_LOGGING_FAILSAFE_TARGET);
-        // do not involve another logging framework, that's the whole point of this failsafe
-        return "stderr".equalsIgnoreCase(configuredTarget) ? System.err : System.out; // NOSONAR see comment above
+        return resolveFailsafeTarget(System.getenv(ENV_LOGGING_FAILSAFE_TARGET), EclipseUtil.getApplication());
+    }
+
+    /**
+     * Resolves the failsafe output stream from the given env-variable value and application type.
+     * <p>
+     * Package-private for testing.
+     *
+     * @param configuredTarget value of {@link #ENV_LOGGING_FAILSAFE_TARGET}, or {@code null} if unset
+     * @param app the currently running application
+     * @return the output stream to write to, or {@code null} if the failsafe is disabled
+     */
+    @SuppressWarnings("resource") // no ownership over System streams
+    static PrintStream resolveFailsafeTarget(final String configuredTarget, final EclipseUtil.Application app) {
+        if ("off".equalsIgnoreCase(configuredTarget)) {
+            return null; // explicitly disabled
+        }
+        if (configuredTarget != null && !configuredTarget.isBlank()) {
+            // do not involve another logging framework, that's the whole point of this failsafe
+            return "stderr".equalsIgnoreCase(configuredTarget) ? System.err : System.out; // NOSONAR see comment above
+        }
+        // env var is unset or blank: enable by default only for AP and EXECUTOR
+        if (app == EclipseUtil.Application.AP || app == EclipseUtil.Application.EXECUTOR) {
+            return System.out; // NOSONAR see comment above
+        }
+        return null; // disabled by default for all other applications
     }
 
     private static Level initFailsafeMinLevel() {


### PR DESCRIPTION
Other applications can opt-in to failsafe logging by explicitly setting ENV variables.

AP-25788 (NodeLogger may swallow buffered log messages if startup is aborted)